### PR TITLE
Update of DM traffic interface

### DIFF
--- a/speedd-runtime/src/main/java/org/speedd/dm/DistributedRM.java
+++ b/speedd-runtime/src/main/java/org/speedd/dm/DistributedRM.java
@@ -36,7 +36,8 @@ public class DistributedRM {
 	 */
 	public onrampStruct processEvent(String eventName, long timestamp, Map<String, Object> attributes) {
 		
-		Integer sensor_Id = (Integer) attributes.get("location");
+		String buffer = (String) attributes.get("sensorId");
+		Integer sensor_Id = Integer.parseInt((String) attributes.get("sensorId"));
 		onrampStruct localRamp = null;
 		
 		if (sensor_Id != null) {
@@ -66,7 +67,7 @@ public class DistributedRM {
 						else localRamp.maxFlow = 1800.; // disable upper limit
 					}
 				}
-				else if (eventName.equals("onrampAverages")) {
+				else if (eventName.equals("AverageOnRampValuesOverInterval")) {
 					Double onrampFlow = (Double)attributes.get("average_flow");
 					// FIXME: Add test that field present. Add test that this is the QUEUE flow
 					
@@ -77,7 +78,7 @@ public class DistributedRM {
 				}
 			}
 		} else {
-			throw(new IllegalArgumentException("Field location in event attributes is empty."));
+			throw(new IllegalArgumentException("Field sensorId in event attributes is empty."));
 		}
 
 		return localRamp;
@@ -98,12 +99,12 @@ public class DistributedRM {
 		onrampStruct localOnramp =  processEvent(eventName, timestamp, attributes);
 		
 		// next line contains as last elment the trigger to issue new ramp metering commands
-		if (!(localOnramp == null) && (localOnramp.operationMode >= 1) && (eventName.equals("onrampAverages"))) {
+		if (!(localOnramp == null) && (localOnramp.operationMode >= 1) && (eventName.equals("AverageOnRampValuesOverInterval"))) {
 			// Create Action Event
 	        Map<String, Object> outAttrs = new HashMap<String, Object>();
 	        outAttrs.put("newMeteringRate", localOnramp.dutycycle); // compute action
-	        outAttrs.put("location", localOnramp.actuatorId);
-	        outAttrs.put("dm_location", (String)attributes.get("dm_location"));
+	        outAttrs.put("sensorId", Integer.toString(localOnramp.actuatorId));
+	        outAttrs.put("dm_sensorId", (String)attributes.get("dm_sensorId"));
 	        
 	        Event outEvent = eventFactory.createEvent("UpdateMeteringRateAction", timestamp, outAttrs);
 			return outEvent;

--- a/speedd-runtime/src/main/java/org/speedd/dm/network.java
+++ b/speedd-runtime/src/main/java/org/speedd/dm/network.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 /**
  * DM traffic use case V2.0:
- * Implementation of traffic network
+ * Implementation of general traffic network
  *
  * @author mschmitt
  *

--- a/speedd-runtime/src/test/java/org/speedd/dm/TestFreeway.java
+++ b/speedd-runtime/src/test/java/org/speedd/dm/TestFreeway.java
@@ -54,24 +54,24 @@ public class TestFreeway {
 		
 		// test "processEvent"
 		Map<String, Object> attributes = new HashMap<String, Object>();
-		attributes.put("location", 403);
+		attributes.put("sensorId", "403");
 		onrampStruct result = controller.processEvent("Congestion", 0, attributes);
 		assertEquals(1, result.ramp);
 		assertEquals(1, result.operationMode);
 		
-		attributes.put("location", 3);
+		attributes.put("sensorId", "3");
 		attributes.put("lowerLimit",(Double) 100.);
 		result = controller.processEvent("setMeteringRateLimits", 0, attributes);
 		assertEquals(1, result.ramp); // should remain from before
 		assertEquals(1, result.operationMode);
 		assertEquals((Double) 100., result.minFlow);
 		
-		attributes.put("location", 3);
+		attributes.put("sensorId", "3");
 		result = controller.processEvent("ClearCongestion", 0, attributes);
 		assertEquals(1, result.ramp);
 		assertEquals(0, result.operationMode);
 		
-		attributes.put("location", 5);
+		attributes.put("sensorId", "5");
 		attributes.put("upperLimit", 2000.);
 		result = controller.processEvent("setMeteringRateLimits", 0, attributes);
 		assertEquals(5, result.ramp);
@@ -99,11 +99,11 @@ public class TestFreeway {
 		init_cars.put(105, 0.);
 		freeway.initDensitites(init_cars); // initialize densities
 		double eps = 1e-6;
-		attributes.put("location", 2);
+		attributes.put("sensorId", "2");
 		attributes.put("lowerLimit", -1.); // disable lower limit
 		controller.processEvent("setMeteringRateLimits", 0, attributes);
 		assertEquals(-1., controller.computeDutyCycle(101, 0, 120./3600), eps); // controller not active 
-		attributes.put("location", 2);
+		attributes.put("sensorId", "2");
 		controller.processEvent("Congestion", 0, attributes);
 		assertEquals(10/60., controller.computeDutyCycle(101, 0, 120./3600), eps); // active
 		init_cars.put(1, 50.);
@@ -112,7 +112,7 @@ public class TestFreeway {
 		init_cars.put(1, 60.);
 		freeway.initDensitites(init_cars); // initialize densities
 		assertEquals(0., controller.computeDutyCycle(101, 0, 120./3600), eps); // above critical density
-		attributes.put("location", 2);
+		attributes.put("sensorId", "2");
 		attributes.put("lowerLimit", 100.); // disable lower limit
 		controller.processEvent("setMeteringRateLimits", 0, attributes);
 		assertEquals(100./1800, controller.computeDutyCycle(101, 0, 120./3600), eps); // above critical density, but lower limit active


### PR DESCRIPTION
Update of DM traffic interface to account for the new event definitions and attribute names, such that we can proceed with integration.

Some events (SetSpeedLimit, SetTrafficLightPhases, PredictedRampOverflow, ClearRampOverflow) are still ignored in this version, also "AggregatedQueueLength" is not yet emitted by DM. The
additional functionalities will be added by updates over the next days.