### PR TITLE
BugFix: Event name for onramp/queue aggregates.

### DIFF
--- a/speedd-runtime/src/main/java/org/speedd/dm/DistributedRM.java
+++ b/speedd-runtime/src/main/java/org/speedd/dm/DistributedRM.java
@@ -87,7 +87,7 @@ public class DistributedRM {
 						else localOnramp.maxFlow = 1800.; // disable upper limit
 					}
 				}
-				else if (eventName.equals("AverageOnRampValuesOverInterval") && (localOnramp.operationMode >= 1) &&
+				else if ((eventName.equals("AverageOnRampValuesOverInterval") || eventName.equals("AverageDensityAndSpeedPersensorIdOverInterval")) && (localOnramp.operationMode >= 1) &&
 						(freeway.Roads.get(onrampId).sensor_begin == (int)sensor_Id)) {
 					// ACTION iff: - ramp metering on onramp is active
 					//   	       - event regarding the external inflow is received

--- a/speedd-runtime/src/main/java/org/speedd/dm/eventDrivenObserver.java
+++ b/speedd-runtime/src/main/java/org/speedd/dm/eventDrivenObserver.java
@@ -93,9 +93,9 @@ public class eventDrivenObserver {
                 		// INTERNAL MEASUREMENT
                 		
                 		// DENSITY UPDATE
-                		if (eventName.equals("AverageDensityAndSpeedPersensorIdOverInterval")) {
+                		if (!road.type.equals("onramp")) {
                 			road.updateDensity(L_DENS * (ncars - ncarsMap.get(roadId)));
-                		} else if (eventName.equals("AverageOnRampValuesOverInterval") && (road.sensor_begin == sensorId)) {
+                		} else if (road.type.equals("onramp") && (road.sensor_begin == sensorId)) {
                 			// queue sensor: can only be used to correct density which is too small
                 			if (ncars > ncarsMap.get(roadId)) {
                 				road.updateDensity(L_DENS * (ncars - ncarsMap.get(roadId)));

--- a/speedd-runtime/src/test/java/org/speedd/dm/TestRandomEventStream.java
+++ b/speedd-runtime/src/test/java/org/speedd/dm/TestRandomEventStream.java
@@ -195,7 +195,7 @@ public class TestRandomEventStream {
 		attrs.put("dmPartition", newSensor.dmPartition);
 		attrs.put("average_occupancy", randGen.nextDouble() * 125.);
 		attrs.put("average_flow", randGen.nextDouble() * 2000);
-		return SpeeddEventFactory.getInstance().createEvent("AverageOnRampValuesOverInterval", timestamp, attrs);
+		return SpeeddEventFactory.getInstance().createEvent("AverageDensityAndSpeedPersensorIdOverInterval", timestamp, attrs);
 	}
 	private Event createLimits(long timestamp) {
 			// Create a limit event


### PR DESCRIPTION
Code now also works if onramp-measurement-events are (incorrectly?)
labelled as ""AverageDensityAndSpeedPersensorIdOverInterval", i.e.
mainline-measurement events.

Apparently, the conventions for distinguishing between onramp and
mainline events have been unclear.